### PR TITLE
Fix inline docs for tenor

### DIFF
--- a/src/VaultFC.sol
+++ b/src/VaultFC.sol
@@ -102,11 +102,10 @@ contract VaultFC is Guarded, IVaultFC, ERC1155Holder {
     /// @notice Decimals of underlier token
     uint256 public immutable override underlierScale;
 
-    /// @notice Notional currency id (1 - cETH, 2 - cDAI, 3 - cUSDC, 4 - cWBTC )
+    /// @notice Notional Finance CurrencyId (1 - cETH, 2 - cDAI, 3 - cUSDC, 4 - cWBTC )
     uint256 public immutable currencyId;
 
-    /// @notice Notional tenor
-    /// (seconds)
+    /// @notice Notional Finance Tenor [seconds]
     uint256 public immutable tenor;
 
     /// @notice The vault type

--- a/src/VaultFC.sol
+++ b/src/VaultFC.sol
@@ -106,7 +106,7 @@ contract VaultFC is Guarded, IVaultFC, ERC1155Holder {
     uint256 public immutable currencyId;
 
     /// @notice Notional tenor
-    /// (1 - Quarter, 2 - Half Year, 3 - Year, 4 - 2 Years, 5 - 5 Years, 6 - 10 Years, 7 - 20 Years)
+    /// (seconds)
     uint256 public immutable tenor;
 
     /// @notice The vault type


### PR DESCRIPTION
tenor documentation uses enumeration of tenors (e.g. 1=3 months, ...) while actual variable is expressed in seconds. bc this is natspec thats shown on etherscan we might want to fix that